### PR TITLE
Fix CodeTemplate InterpretationFunction bug

### DIFF
--- a/StackExchange.m
+++ b/StackExchange.m
@@ -416,7 +416,7 @@ styleNB = Notebook[
 				"Text",
 				ShowStringCharacters -> False
 			]&),
-			InterpretationFunction->(Cell[TextData[{"``", Cell@BoxData@#1, "``"}]]&)
+			InterpretationFunction->(Cell[TextData[{"``", Cell@BoxData@#2, "``"}]]&)
 		}
 	],
 	Cell[StyleData["TeXTemplate"],


### PR DESCRIPTION
Should use #2, not #1 in the function.