### PR TITLE
Add explicit ShowCellLabel options

### DIFF
--- a/StackExchange/StyleSheetFunctions.m
+++ b/StackExchange/StyleSheetFunctions.m
@@ -222,6 +222,15 @@ createTeX[HoldComplete[expr_]] := ToString[Unevaluated[expr], TeXForm]
 $Stylesheet = Notebook[
 	{
 	Cell[StyleData[StyleDefinitions->"Default.nb"]],
+	Cell[StyleData["Notebook"],
+		ShowCellLabel->False
+	],
+	Cell[StyleData["Input"],
+		ShowCellLabel->True
+	],
+	Cell[StyleData["Output"],
+		ShowCellLabel->True
+	],
 	Cell[StyleData["Code"],
 		StyleKeyMapping -> {"Tab" -> "CodeBlock"}
 	],
@@ -526,6 +535,3 @@ InstallStylesheet[] := NotebookPut[$Stylesheet]
 End[]
 
 EndPackage[]
-
-
-


### PR DESCRIPTION
Notebook needs ShowCellLabel->False so that copied In/Out cells don't have cell labels.
Input/Output needs ShowCellLabel->True so that one can see them in a notebook.